### PR TITLE
README.md fix 

### DIFF
--- a/project-1-favorites/README.md
+++ b/project-1-favorites/README.md
@@ -2,7 +2,7 @@
 
 This is a basic Anchor app using PDAs to store data for a user, and Anchor's account checks to ensure each user is only allowed to modify their own data.
 
-It's used by the [https://github.com/solana-developers/professional-education](Solana Professional Education) course.
+It's used by the [Solana Professional Education](https://github.com/solana-developers/professional-education) course.
 
 We recommend creating a separate github repository for each project and commiting your code as you follow along the video.
 


### PR DESCRIPTION
There was an issue with how the link to Solana professional course was formatted, (link should have been placed after placeholder text, earlier link was not working)
<img width="1280" height="265" alt="image" src="https://github.com/user-attachments/assets/abee7609-8cec-45ca-a9d1-99eb0eeb3f6f" />
Before the changes (Link will take you to 404 page of github) 
<img width="1280" height="265" alt="image" src="https://github.com/user-attachments/assets/e291842e-ad22-4826-89dc-43c6e67ed185" />
 After 
 
 An issue I'd like to raise is,  Does this link need to be included in the readme? it seems to be a template repository for making courses and irrelevant 