### PR TITLE
feat: fix voting program bugs in projects 2 and 13

### DIFF
--- a/project-13-getting-to-production/anchor/programs/voting/src/lib.rs
+++ b/project-13-getting-to-production/anchor/programs/voting/src/lib.rs
@@ -35,6 +35,17 @@ pub mod voting {
 
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
+        let poll = &ctx.accounts.poll;
+        let current_time = Clock::get()?.unix_timestamp;
+
+        if current_time < (poll.poll_start as i64) {
+            return Err(ErrorCode::VotingNotStarted.into());
+        }
+
+        if current_time > (poll.poll_end as i64) {
+            return Err(ErrorCode::VotingEnded.into());
+        }
+
         candidate.candidate_votes += 1;
         msg!("Voted for candidate: {}", candidate.candidate_name);
         msg!("Votes: {}", candidate.candidate_votes);
@@ -120,4 +131,12 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("Voting has not started yet")]
+    VotingNotStarted,
+    #[msg("Voting has ended")]
+    VotingEnded,
 }

--- a/project-2-voting/anchor/programs/voting/src/lib.rs
+++ b/project-2-voting/anchor/programs/voting/src/lib.rs
@@ -70,6 +70,7 @@ pub struct InitializeCandidate<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
+    #[account(mut)]
     pub poll_account: Account<'info, PollAccount>,
 
     #[account(


### PR DESCRIPTION
## Summary
This PR fixes two common bugs in the voting programs found in projects 2 and 13:
1. **Project 2**: Added `#[account(mut)]` to `poll_account` in the `initialize_candidate` instruction to allow updating the `poll_option_index`.
2. **Project 13**: Added time checks (`poll_start` and `poll_end`) to the `vote` instruction to ensure voting only occurs within the allowed period.

## Changes
- `project-2-voting/anchor/programs/voting/src/lib.rs`: Updated `InitializeCandidate` account struct.
- `project-13-getting-to-production/anchor/programs/voting/src/lib.rs`: Added `ErrorCode` and implemented time validation in `vote` function.

Please note: These fixes were implemented based on common issues identified in the Solana Devs India Tour Workshop materials.
